### PR TITLE
Safely source xrd.sh

### DIFF
--- a/xrd.sh
+++ b/xrd.sh
@@ -605,7 +605,14 @@ fi
 }
 
 ## Allow loading functions as library
-[[ "${BASH_SOURCE[0]}" != "${0}" ]] && echo "Warning: using xrd.sh as library!" && return 0;
+#  Warns unless SKIPWARN_XRDSH_ASLIB is set
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]
+then
+    if [[ -z "${SKIPWARN_XRDSH_ASLIB}" ]]; then
+        echo "Warning: using xrd.sh as library!"
+    fi
+    return 0
+fi
 
 set_formatters
 check_prerequisites

--- a/xrd.sh
+++ b/xrd.sh
@@ -603,7 +603,7 @@ else
     echo " [-getkeys] just get keys";
     echo "";
     echo "Environment variables:";
-    echo "  SKIPWARN_XRDSH_ASLIB  do not warn xrd.sh is sourced"
+    echo "  XRDSH_NOWARN_ASLIB  do not warn xrd.sh is sourced"
 fi
 }
 
@@ -611,7 +611,7 @@ fi
 #  Warns unless SKIPWARN_XRDSH_ASLIB is set
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]
 then
-    if [[ -z "${SKIPWARN_XRDSH_ASLIB}" ]]; then
+    if [[ -z "${XRDSH_NOWARN_ASLIB}" ]]; then
         echo "Warning: using xrd.sh as library!"
     fi
     return 0

--- a/xrd.sh
+++ b/xrd.sh
@@ -10,7 +10,6 @@ SETCOLOR_FAILURE="echo -en \\033[1;31m"
 SETCOLOR_WARNING="echo -en \\033[1;33m"
 SETCOLOR_NORMAL="echo -en \\033[0;39m"
 }
-set_formatters
 
 ######################################
 check_prerequisites() {
@@ -18,7 +17,6 @@ check_prerequisites() {
 [ ! -e "/usr/bin/wget" ] && { echo "wget command not found; do : yum -y install wget.x86_64"; exit 1; }
 [ ! -e "/usr/bin/curl" ] && { echo "curl command not found; do : yum -y install wget.x86_64"; exit 1; }
 }
-check_prerequisites
 
 set_system() {
 # Define system settings
@@ -84,7 +82,6 @@ else
     XRDHOME=$HOME
 fi
 }
-set_system
 
 ##########  FUNCTIONS   #############
 echo_success() {
@@ -610,4 +607,7 @@ fi
 ## Allow loading functions as library
 [[ "$0" == "bash" ]] && echo "Warning: using xrd.sh as library!" && return 0;
 
+set_formatters
+check_prerequisites
+set_system
 xrdsh_main

--- a/xrd.sh
+++ b/xrd.sh
@@ -605,7 +605,7 @@ fi
 }
 
 ## Allow loading functions as library
-[[ "$0" == "bash" ]] && echo "Warning: using xrd.sh as library!" && return 0;
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && echo "Warning: using xrd.sh as library!" && return 0;
 
 set_formatters
 check_prerequisites

--- a/xrd.sh
+++ b/xrd.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-## execute the script NOT source
-[[ "$0" == "bash" ]] && echo "Error:  Please don't source me - just execute me!" && exit 1;
-
 ######################################
 set_formatters() {
 BOOTUP=color
@@ -609,4 +606,8 @@ else
     echo " [-getkeys] just get keys";
 fi
 }
+
+## Allow loading functions as library
+[[ "$0" == "bash" ]] && echo "Warning: using xrd.sh as library!" && return 0;
+
 xrdsh_main

--- a/xrd.sh
+++ b/xrd.sh
@@ -4,6 +4,7 @@
 [[ "$0" == "bash" ]] && echo "Error:  Please don't source me - just execute me!" && exit 1;
 
 ######################################
+set_formatters() {
 BOOTUP=color
 RES_COL=60
 MOVE_TO_COL="echo -en \\033[${RES_COL}G"
@@ -11,11 +12,20 @@ SETCOLOR_SUCCESS="echo -en \\033[1;32m"
 SETCOLOR_FAILURE="echo -en \\033[1;31m"
 SETCOLOR_WARNING="echo -en \\033[1;33m"
 SETCOLOR_NORMAL="echo -en \\033[0;39m"
+}
+set_formatters
 
-## checking prereqisites
+######################################
+check_prerequisites() {
 [ ! -e "/usr/bin/dig" ] && { echo "dig command not found; do : yum -y install bind-utils.x86_64"; exit 1; }
 [ ! -e "/usr/bin/wget" ] && { echo "wget command not found; do : yum -y install wget.x86_64"; exit 1; }
-[ ! -e "/usr/bin/curl" ] && { echo "wget command not found; do : yum -y install wget.x86_64"; exit 1; }
+[ ! -e "/usr/bin/curl" ] && { echo "curl command not found; do : yum -y install wget.x86_64"; exit 1; }
+}
+check_prerequisites
+
+set_system() {
+# Define system settings
+# Find configs, dirs, xrduser, ...
 
 # set arch for lib definition
 [[ "`/bin/arch`" == "x86_64" ]] && export BITARCH=64
@@ -76,6 +86,8 @@ if [[ "$USER" == "root" ]]; then
 else
     XRDHOME=$HOME
 fi
+}
+set_system
 
 ##########  FUNCTIONS   #############
 echo_success() {
@@ -535,6 +547,7 @@ exit $returnval
 ######################
 ##    Main logic    ##
 ######################
+xrdsh_main() {
 if [[ "$1" == "-c" ]]; then  ## check and restart if not running
     removecron
     checkkeys
@@ -595,4 +608,5 @@ else
     echo " [-conf] just (re)create configuration";
     echo " [-getkeys] just get keys";
 fi
-
+}
+xrdsh_main

--- a/xrd.sh
+++ b/xrd.sh
@@ -601,6 +601,9 @@ else
     echo " [-logs] manage the logs";
     echo " [-conf] just (re)create configuration";
     echo " [-getkeys] just get keys";
+    echo "";
+    echo "Environment variables:";
+    echo "  SKIPWARN_XRDSH_ASLIB  do not warn xrd.sh is sourced"
 fi
 }
 


### PR DESCRIPTION
The changes allow sourcing `xrd.sh` to use it as a library. A sourcing script is free to e.g. replace functions or overwrite variables. This makes it easier to modify the behavior of `xrd.sh` if a local setup requires modifications.

If `xrd.sh` is sourced, it will no longer kill the calling script and no code is executed. All code is made available as functions.

When sourcing `xrd.sh`, a warning is still printed by default. The warning can be turned off by setting `XRDSH_NOWARN_ASLIB`.

Indentation and whitespace is not changed by this PR to make functional changes obvious.
