### PR TITLE
Cleanup of server/manager variables

### DIFF
--- a/xrd.sh
+++ b/xrd.sh
@@ -171,15 +171,13 @@ serverinfo() {
 
   ##  What i am?
   # default role - server
-  role="server"; server="yes"; nproc=1;
+  server="yes"; manager=""; nproc=1;
 
   # unless i am manager
   if [[ "x$myhost" == "x$MANAGERHOST" ]]; then
-    role="manager";
     manager="yes";
     server="";
     if [[ "x$SERVERONREDIRECTOR" = "x1" ]]; then # i am am both add server role
-      role="all";
       server="yes";
       nproc=2;
     fi
@@ -188,7 +186,6 @@ serverinfo() {
   export MONALISA_HOST
   export MANAGERHOST
   export LOCALPATHPFX
-  export role
   export manager
   export server
   export nproc

--- a/xrd.sh
+++ b/xrd.sh
@@ -352,7 +352,7 @@ removecron() {
 bootstrap() {
   createconf
   mkdir -p ${LOCALROOT}/${LOCALPATHPFX}
-  [[ "${role}" == "server" ]] && chown $XRDUSER ${LOCALROOT}/${LOCALPATHPFX}
+  [[ "${server}" == "yes" ]] && chown $XRDUSER ${LOCALROOT}/${LOCALPATHPFX}
 }
 
 ######################################


### PR DESCRIPTION
Minor cleanup of the `role` and `manager`/`server` variables, since they're redundant. This makes it simpler to overwrite (see previous PR) which services to start.

This PR also removes an ambiguity in `bootstrap`: a `server` behaved slightly different when deployed alongside a manager. I've removed `role` since it was only used for this check.
